### PR TITLE
Added text color button to editor toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,17 @@
             <button id="btn-list-unordered">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-icon lucide-list"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg>
             </button>
-            
+            <!-- Color Picker Button Code -->
+            <button id="btn-text-color" title="Text Color">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-palette">
+                <circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/>
+                <circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/>
+                <circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/>
+                <circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/>
+                <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/>
+                </svg>
+                <input type="color" id="color-picker" value="#ffff00" style="opacity:0; width:0; height:0; border:none; padding:0; margin:0;">
+            </button>
         </div>
         <div id="text-content" contenteditable="true" >
         </div>

--- a/scripts/editor.js
+++ b/scripts/editor.js
@@ -47,3 +47,17 @@ document.getElementById("btn-list-unordered").addEventListener("click", () => {
     document.execCommand("insertUnorderedList");
     textContent.focus();
 })
+
+// Text color functionality
+document.getElementById("btn-text-color").addEventListener("click", () => {
+    const colorPicker = document.getElementById("color-picker");
+    colorPicker.click();
+});
+
+// Apply color to selected text immediately when color is picked
+document.getElementById("color-picker").addEventListener("input", (e) => {
+    const color = e.target.value;
+    if (window.getSelection().toString()) {
+        document.execCommand("foreColor", false, color);
+    }
+});

--- a/styles/style.css
+++ b/styles/style.css
@@ -76,3 +76,12 @@ option {
 #text-content:focus {
     outline: 0px solid transparent;
 }
+
+/* Color Picker Styles */
+#btn-text-color {
+    position: relative;
+}
+
+#btn-text-color:hover #color-picker {
+    pointer-events: auto;
+}


### PR DESCRIPTION
Implemented a **Text Color** button to the editor toolbar to allow users to change the color of selected text.

**Changes Made:**
**HTML:** Added a new toolbar button with a palette icon and a hidden color input.
**CSS:** Styled the color picker input so it stays hidden but usable.
**JavaScript:**
- Opens the color picker when the button is clicked.
- Applies the chosen color immediately to the selected text using `document.execCommand("foreColor")`.

This implements the requested feature giving users the ability to customize text color directly from the toolbar.

**Preview:**
- Click the palette icon to open the color picker.
- Select a color → the selected text updates instantly with the chosen color.